### PR TITLE
Twelve: Don't request ACCESS_MEDIA_LOCATION

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="org.lineageos.twelve">
 
-    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/app/src/main/java/org/lineageos/twelve/utils/PermissionsUtils.kt
+++ b/app/src/main/java/org/lineageos/twelve/utils/PermissionsUtils.kt
@@ -21,7 +21,5 @@ object PermissionsUtils {
         } else {
             add(Manifest.permission.READ_EXTERNAL_STORAGE)
         }
-
-        add(Manifest.permission.ACCESS_MEDIA_LOCATION)
     }.toTypedArray()
 }


### PR DESCRIPTION
This is only required to read EXIF metadata from photos
