### PR TITLE
Twelve: Set album image to music note once

### DIFF
--- a/app/src/main/java/org/lineageos/twelve/fragments/NowPlayingFragment.kt
+++ b/app/src/main/java/org/lineageos/twelve/fragments/NowPlayingFragment.kt
@@ -163,6 +163,9 @@ class NowPlayingFragment : Fragment(R.layout.fragment_now_playing) {
             activity.startActivity(intent)
         }
 
+        // Reset album art
+        albumArtImageView.setImageResource(R.drawable.ic_music_note)
+
         viewLifecycleOwner.lifecycleScope.launch {
             viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 launch {
@@ -200,7 +203,7 @@ class NowPlayingFragment : Fragment(R.layout.fragment_now_playing) {
                                     }.also { bitmap ->
                                         albumArtImageView.setImageBitmap(bitmap)
                                     }
-                                } ?: albumArtImageView.setImageResource(R.drawable.ic_music_note)
+                                }
 
                                 val audioTitle = playbackStatus.mediaMetadata.displayTitle
                                     ?: playbackStatus.mediaMetadata.title


### PR DESCRIPTION
Otherwise we have random flickers switching between
songs within an album (that have the same image)
