### PR TITLE
Twelve: Set room schema location via javacflags

### DIFF
--- a/app/Android.bp
+++ b/app/Android.bp
@@ -33,6 +33,9 @@ android_app {
     plugins: [
         "androidx.room_room-compiler-plugin",
     ],
+    javacflags: [
+        "-Aroom.schemaLocation=packages/apps/Twelve/app/schemas",
+    ],
 
     static_libs: [
         // DO NOT EDIT THIS SECTION MANUALLY


### PR DESCRIPTION
Allows auto migrations to work via the java plugin
